### PR TITLE
Stop traversing AST when we found the type

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,15 +14,13 @@ function fromSource(source) {
   }
 
   var walker = new Walker();
+  var type = 'none';
   var hasDefine = false;
   var hasAMDTopLevelRequire = false;
   var hasRequire = false;
   var hasExports = false;
   var hasES6Import = false;
   var hasES6Export = false;
-  var isAMD;
-  var isCommonJS;
-  var isES6;
 
   // Walker accepts as AST to avoid reparsing
   walker.walk(source, function(node) {
@@ -49,26 +47,24 @@ function fromSource(source) {
     if (types.isES6Export(node)) {
       hasES6Export = true;
     }
+
+    if (hasES6Import || hasES6Export) {
+      type = 'es6';
+      return walker.stopWalking();
+    }
+
+    if (hasDefine || hasAMDTopLevelRequire) {
+      type = 'amd';
+      return walker.stopWalking();
+    }
+
+    if (hasExports || (hasRequire && !hasDefine)) {
+      type = 'commonjs';
+      return walker.stopWalking();
+    }
   });
 
-  isAMD = hasDefine || hasAMDTopLevelRequire;
-  isCommonJS = hasExports || (hasRequire && !hasDefine);
-  isES6 = hasES6Import || hasES6Export;
-
-  // ES6 features are so unique that we can eagerly exit. (#19)
-  if (isES6) {
-    return 'es6';
-  }
-
-  if (isAMD) {
-    return 'amd';
-  }
-
-  if (isCommonJS) {
-    return 'commonjs';
-  }
-
-  return 'none';
+  return type;
 }
 
 /**


### PR DESCRIPTION
There's no need to keep traversing the entire AST when we found a module type.

This fix will dramatically improve the performance in [dependency-tree](https://github.com/mrjoelkemp/node-dependency-tree). After updating [precinct](https://github.com/mrjoelkemp/precinct) and [filing-cabinet](https://github.com/mrjoelkemp/filing-cabinet) to use the modified `module-definition` module the `dependency-tree` CLI time went from 8s to 3s on the ESLint project.

